### PR TITLE
call `remove()` instead of accessing `DeviceEventEmitter` in `PaymentRequest._removeListeners`

### DIFF
--- a/lib/js/PaymentRequest.js
+++ b/lib/js/PaymentRequest.js
@@ -414,16 +414,12 @@ export default class PaymentRequest {
 
   _removeEventListeners() {
     // Internal Events
-    DeviceEventEmitter.removeSubscription(this._userDismissSubscription);
-    DeviceEventEmitter.removeSubscription(this._userAcceptSubscription);
+    this._userDismissSubscription?.remove?.()
+    this._userAcceptSubscription?.remove?.()
 
     if (IS_IOS) {
-      DeviceEventEmitter.removeSubscription(
-        this._shippingAddressChangeSubscription
-      );
-      DeviceEventEmitter.removeSubscription(
-        this._shippingOptionChangeSubscription
-      );
+      this._shippingAddressChangeSubscription?.remove?.()
+      this._shippingOptionChangeSubscription?.remove?.()
     }
   }
 


### PR DESCRIPTION
Backporting patch from `metamask-mobile`.
- [introducing patch](https://github.com/MetaMask/metamask-mobile/pull/3509/files#diff-8f9b7eb32330c91c0a0f5562e1ba5b43dfbd9cf76277765898f3bc5aece73c96)
- [mobile `main`](https://github.com/MetaMask/metamask-mobile/blob/d5f5460d41bce44c527c834279775c156e3e3448/patches/%40exodus%2Breact-native-payments%2B1.5.0.patch#L35)

### Related
- #4